### PR TITLE
fix: assets front compose down

### DIFF
--- a/assets/services/assets-front/package.json
+++ b/assets/services/assets-front/package.json
@@ -19,7 +19,7 @@
     "release": "standard-version",
     "docker": "docker-compose up --build",
     "docker:detached": "docker-compose up --build -d",
-    "docker:down": "docker-compose up --build down"
+    "docker:down": "docker-compose down"
   },
   "dependencies": {
     "@ant-design/charts": "1.2.11",


### PR DESCRIPTION
Fixed `docker:down` script in assets-front.