### PR TITLE
Fix bug where two decimal numbers added give wrong output

### DIFF
--- a/assets/services/assets-api/src/modules/v2Partition/partition.service/index.ts
+++ b/assets/services/assets-api/src/modules/v2Partition/partition.service/index.ts
@@ -13,6 +13,7 @@ import {
 } from 'src/types/token';
 import { hexaToASCII, ASCIIToHexa } from 'src/utils/hex';
 import { checkSolidityBytes32 } from 'src/utils/solidity';
+import { addNumbersByConvertingIntoBigNumber } from "src/utils/number";
 
 @Injectable()
 export class PartitionService {
@@ -281,10 +282,9 @@ export class PartitionService {
           partitionClass
         ].reduce((supply: number, currentAssetState: AssetStateOnChainData) => {
           return (
-            supply +
-            currentAssetState[
+            addNumbersByConvertingIntoBigNumber(supply, currentAssetState[
               TokenKeys.ASSET_CLASSES_ON_CHAIN_STATES_TOTAL_SUPPLY
-            ]
+            ])
           );
         }, 0);
         const assetClassOnChainData: AssetClassOnChainData = {

--- a/assets/services/assets-api/src/modules/v2Token/token.service/index.ts
+++ b/assets/services/assets-api/src/modules/v2Token/token.service/index.ts
@@ -51,6 +51,7 @@ import {
   DocumentKeys,
   GeneralDataKeys,
 } from 'src/types/asset';
+import { addNumbersByConvertingIntoBigNumber } from "src/utils/number";
 
 const funderAddress: string = process.env.FUNDER_ADDRESS;
 
@@ -427,8 +428,9 @@ export class TokenHelperService {
           ? assetClassesOnChainData.reduce(
               (supply: number, assetClassData: AssetClassOnChainData) => {
                 return (
-                  supply +
-                  assetClassData[TokenKeys.ASSET_CLASSES_ON_CHAIN_TOTAL_SUPPLY]
+                  addNumbersByConvertingIntoBigNumber(supply, assetClassData[
+                    TokenKeys.ASSET_CLASSES_ON_CHAIN_STATES_TOTAL_SUPPLY
+                  ])
                 );
               },
               0,

--- a/assets/services/assets-api/src/utils/number.ts
+++ b/assets/services/assets-api/src/utils/number.ts
@@ -6,7 +6,7 @@ export const MAX_SUPPORTED_INTEGER = 1000000000000000;
 export const MIN_SUPPORTED_INTEGER = 0;
 
 /**
- * Function if integer is not to big in order to avoid 'overflow' in database
+ * Function if integer is not too big in order to avoid 'overflow' in database
  */
 export const checkIntegerFormat = (
   quantity: number,
@@ -93,5 +93,32 @@ export const addDecimalsAndConvertToHex = (number, decimals): string => {
       500,
     );
     throw new Error(`addDecimalsAndConvertToHex --> ${error.message}`);
+  }
+};
+
+/**
+ * [Add Numbers By Converting Into BigNumber]
+ *
+ * The purpose of this function is to add numbers after converting
+ * them to BigNumber and then return the Number
+ *
+ * This function is used everytime we add two numbers.
+ *
+ */
+export const addNumbersByConvertingIntoBigNumber = (number1, number2): number => {
+  try {
+    const number1Bn = new BigNumber(number1);
+    const number2Bn = new BigNumber(number2);
+    const sumBn = number1Bn.plus(number2Bn);
+    return parseFloat(sumBn.toString());
+  } catch (error) {
+    ErrorService.logAndThrowFunctionError(
+      error,
+      `Failed to add numbers ${number1} and ${number2} by converting to BigNumber first`,
+      'addNumbersByConvertingIntoBigNumber',
+      false,
+      500,
+    );
+    throw new Error(`addNumbersByConvertingIntoBigNumber --> ${error.message}`);
   }
 };


### PR DESCRIPTION
## Description

I have added a fix for bug where two decimal numbers when added gives wrong output

## Motivation and Context

In the code when comparing the totalSupply of token and addition of all partitions of token is done, it wasn't matching because the addition was done in Type "Numbers", to fix we have added a function which first coverts them into BigNumber and then add.
For example - 
const num1 = 11031862.87;
const num2 = 2.03;

**(current scenario)**
const result1 = num1 + num2;
console.log(result1); // Output: 11031864.899999999

**(fixed scenario)**
const bigNum1 = new BigNumber(num1);
const bigNum2 = new BigNumber(num2);

const result2 = bigNum1.plus(bigNum2);
console.log(result2.toString()); // Output: 11031864.9


## How Has This Been Tested?

Tested in local environment and nodeJs playgorud - https://codesandbox.io/s/bignumber-js-forked-u4qny6

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.